### PR TITLE
Adjust documentation for ease-of-use

### DIFF
--- a/blue_heron/README.md
+++ b/blue_heron/README.md
@@ -44,7 +44,7 @@ can hit some Nerves use cases too.
 
 ## Getting started
 
-See the examples for the time being.
+See the [examples](../examples) for the time being.
 
 ## Transports
 

--- a/examples/govee_bulb/README.md
+++ b/examples/govee_bulb/README.md
@@ -8,6 +8,31 @@ Bulb](https://www.amazon.com/MINGER-Dimmable-Changing-Equivalent-Multi-Color/dp/
 On a Linux PC where `bluetoothd` immediately grabs the Bluetooth USB module as
 soon as it's inserted, here's the current procedure: (yes, this isn't ideal)
 
+Before you begin you need to find the vendor id (`vid`) and product id (`pid`) of your bluetooth adapter. One way of doing that is by inspecting the output of `dmesg` after plugging in your adapter:
+
+<details>
+  <summary>Example dmesg output</summary>
+  ```
+  [174634.130045] usb 1-9: new full-speed USB device number 8 using xhci_hcd
+  [174634.453638] usb 1-9: New USB device found, idVendor=0a5c, idProduct=21e8, bcdDevice= 1.12
+  [174634.453643] usb 1-9: New USB device strings: Mfr=1, Product=2, SerialNumber=3
+  [174634.453645] usb 1-9: Product: BCM20702A0
+  [174634.453647] usb 1-9: Manufacturer: Broadcom Corp
+  [174634.453649] usb 1-9: SerialNumber: 00190E112B40
+  [174634.513882] audit: type=1130 audit(1599509227.196:198): pid=1 uid=0 auid=4294967295 ses=4294967295 msg='unit=systemd-rfkill comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success'
+  [174634.581454] Bluetooth: hci0: BCM: chip id 63
+  [174634.584453] Bluetooth: hci0: BCM: features 0x07
+  [174634.602454] Bluetooth: hci0: BCM20702A
+  [174634.602459] Bluetooth: hci0: BCM20702A1 (001.002.014) build 0000
+  [174634.604527] Bluetooth: hci0: BCM20702A1 'brcm/BCM20702A1-0a5c-21e8.hcd' Patch
+  [174636.066728] Bluetooth: hci0: Broadcom Bluetooth Device
+  [174636.066733] Bluetooth: hci0: BCM20702A1 (001.002.014) build 1459
+  [174639.517580] audit: type=1131 audit(1599509232.199:199): pid=1 uid=0 auid=4294967295 ses=4294967295 msg='unit=systemd-rfkill comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success'
+  ```
+
+  In this example the vid is `0a5c`, and the pid is `21e8`, which can be written in elixir hex notation as `0x0a5c` and `0x21e8`.
+</details>
+
 ```sh
 $ sudo systemctl stop bluetooth
 
@@ -23,7 +48,8 @@ $ sudo chmod +s ./_build/dev/lib/blue_heron_transport_usb/priv/hci_transport
 
 # Run Elixir interactively
 $ iex -S mix
-iex> {:ok, pid} = GoveeBulb.start_link(:usb, vid: 0x0bda, pid: 0xb82c)
+# Use the pid and vid you found earlier here:
+iex> {:ok, pid} = GoveeBulb.start_link(:usb, %{vid: 0x0bda, pid: 0xb82c})
 iex> GoveeBulb.set_color(pid, 0xFFFF40)
 ```
 
@@ -34,6 +60,7 @@ gist](https://gist.github.com/fhunleth/fae46998609814ae4a8abd44f6f08188#setting-
 for making a Raspberry Pi Zero W into a Bluetooth UART module for your laptop.
 
 ```elixir
-{:ok, pid} = GoveeBulb.start_link(:uart, device: "ttyACM0")
+# Note: your uart device may be something different than /dev/ttyACM0, in that case substitute it here
+{:ok, pid} = GoveeBulb.start_link(:uart, %{device: "ttyACM0"})
 GoveeBulb.set_color(pid, 0xFFFF40)
 ```

--- a/examples/govee_bulb/lib/govee_bulb.ex
+++ b/examples/govee_bulb/lib/govee_bulb.ex
@@ -23,15 +23,15 @@ defmodule GoveeBulb do
   # Sets the name of the BLE device
   @write_local_name %WriteLocalName{name: "Govee Controller"}
 
-  @usb_config %BlueHeronTransportUSB{
-    vid: 0x0BDA,
-    pid: 0xB82C,
+  @default_uart_config %{
+    device: "ttyACM0",
+    uart_opts: [speed: 115_200],
     init_commands: [@write_local_name]
   }
 
-  @uart_config %BlueHeronTransportUART{
-    device: "ttyACM0",
-    uart_opts: [speed: 115_200],
+  @default_usb_config %{
+    vid: 0x0BDA,
+    pid: 0xB82C,
     init_commands: [@write_local_name]
   }
 
@@ -51,11 +51,13 @@ defmodule GoveeBulb do
   def start_link(transport_type, config \\ %{})
 
   def start_link(:uart, config) do
-    GenServer.start_link(__MODULE__, struct(@uart_config, config), [])
+    config = struct(BlueHeronTransportUART, Map.merge(@default_uart_config, config))
+    GenServer.start_link(__MODULE__, config, [])
   end
 
   def start_link(:usb, config) do
-    GenServer.start_link(__MODULE__, struct(@usb_config, config), [])
+    config = struct(BlueHeronTransportUSB, Map.merge(@default_usb_config, config))
+    GenServer.start_link(__MODULE__, config, [])
   end
 
   @doc """


### PR DESCRIPTION
There's a couple changes in here:
* Give an example of finding your usb vendor and product ids (otherwise `vid` and `pid` are not very explanatory by themselves)
* Tell the user the specific values they need to set up for their own devices
* Don't rely on both structs being available at compile time
  * Since nerves doesn't currently compile with libusb the user would have to manually comment out the `%BlueHeronTransportUSB{}` reference