### PR TITLE
WIP add ability to compile libusb in band

### DIFF
--- a/blue_heron_transport_usb/Makefile
+++ b/blue_heron_transport_usb/Makefile
@@ -26,8 +26,16 @@ PORT = $(PREFIX)/hci_transport
 CFLAGS ?= -O2 -Wno-unused-parameter -pedantic -Wall
 CFLAGS += $(TARGET_CFLAGS) -Wall -pedantic
 
-LDFLAGS += $(shell pkg-config libusb-1.0 --libs)
-CFLAGS +=  $(shell pkg-config libusb-1.0 --cflags)
+LIBUSB_VERSION_MAJOR = 1.0
+LIBUSB_VERSION = $(LIBUSB_VERSION_MAJOR).23
+LIBUSB_SOURCE = libusb-$(LIBUSB_VERSION).tar.bz2
+LIBUSB_SITE = https://github.com/libusb/libusb/releases/download/v$(LIBUSB_VERSION)
+LIBUSB = $(PREFIX)/lib/libusb-1.0.a
+LIBUSB_BUILD = $(MIX_APP_PATH)/libusb-1.0.23
+LIBUSB_CFLAGS += -I$(PREFIX)/include
+LIBUSB_LDFLAGS += -L$(PREFIX)/lib -lusb-1.0
+CFLAGS += $(LIBUSB_CFLAGS)
+LDFLAGS += $(LIBUSB_LDFLAGS)
 
 # # Set Erlang-specific compile and linker flags
 # ERL_CFLAGS ?= -I$(ERL_EI_INCLUDE_DIR)
@@ -49,8 +57,16 @@ $(OBJ): $(HEADERS) Makefile
 $(BUILD)/%.o: src/%.c
 	$(CC) -c $(CFLAGS) -o $@ $<
 
-$(PORT): $(OBJ)
-	$(CC) -o $@ $^ $(LDFLAGS)
+$(PORT): $(LIBUSB) $(OBJ)
+	$(CC) -o $@ $(OBJ) $(LDFLAGS)
+
+$(LIBUSB): $(MIX_APP_PATH)/$(LIBUSB_SOURCE)
+	tar -xjf $(MIX_APP_PATH)/$(LIBUSB_SOURCE) -C $(MIX_APP_PATH)
+	cd $(LIBUSB_BUILD) && ./configure --disable-udev --prefix=$(PREFIX)
+	cd $(LIBUSB_BUILD) && $(MAKE) install
+
+$(MIX_APP_PATH)/$(LIBUSB_SOURCE):
+	wget -O $(MIX_APP_PATH)/$(LIBUSB_SOURCE) $(LIBUSB_SITE)/$(LIBUSB_SOURCE)
 
 $(PREFIX) $(BUILD):
 	mkdir -p $@


### PR DESCRIPTION
Fixes #36 
This adds a step to the usb compile step where it will download libusb and install it in the `priv` dir to be linked against.
it's only partially implemented right now, but i wanted to start a discussion on doing this before fully implementing it.

Notable problems as of right now:

1) it will **always** download/build libusb with this change. Ideally, it would only do this if it couldn't find it in the first place.
2) `LD_LIBRARY_PATH` will need to be set to actually be able to use this at runtime. 
3) we could static link libusb to avoid 2.