### PR TITLE
Add configurable and current ATT MTU handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ is the addition of a supervision tree. Upgrading to this release requires a few 
       device: "/dev/ttyS0",
       speed: 115_200,
       flow_control: :hardware
+    ],
+    peripheral: [
+      local_mtu: 512
     ]
    ```
 3) Remove `BlueHeron.Peripheral.start_link/2` calls. The Peripheral

--- a/lib/blue_heron/application.ex
+++ b/lib/blue_heron/application.ex
@@ -13,6 +13,7 @@ defmodule BlueHeron.Application do
   def start(_type, _args) do
     all_env = Application.get_all_env(:blue_heron)
     transport_args = Keyword.get(all_env, :transport, [])
+    peripheral_args = Keyword.get(all_env, :peripheral, [])
     smp_args = Keyword.get(all_env, :smp, [])
     broadcaster_args = Keyword.get(all_env, :broadcaster, [])
 
@@ -27,7 +28,7 @@ defmodule BlueHeron.Application do
       BlueHeron.ACLBuffer,
       {BlueHeron.Broadcaster, broadcaster_args},
       {BlueHeron.SMP, smp_args},
-      BlueHeron.Peripheral,
+      {BlueHeron.Peripheral, peripheral_args},
       {BlueHeron.HCI.Transport, transport_args}
     ]
 

--- a/lib/blue_heron/gatt/server.ex
+++ b/lib/blue_heron/gatt/server.ex
@@ -94,30 +94,43 @@ defmodule BlueHeron.GATT.Server do
   alias BlueHeron.GATT.{Characteristic, Service}
   alias BlueHeron.SMP
 
-  defstruct [:profile, :mtu, :read_buffer, :write_requests]
+  defstruct [:profile, :local_mtu, :mtu, :read_buffer, :write_requests]
 
   @discover_all_primary_services 0x2800
   @find_included_services 0x2802
   @discover_all_characteristics 0x2803
   @cccd 0x2902
+  @default_mtu 23
 
   @opaque t() :: %__MODULE__{
             profile: [Service.t()],
+            local_mtu: non_neg_integer(),
             mtu: non_neg_integer(),
             read_buffer: binary(),
             write_requests: [binary()]
           }
 
   @doc false
-  def init(profile) do
+  def init(profile, local_mtu \\ @default_mtu) do
     profile = hydrate(profile)
 
     %__MODULE__{
       profile: profile,
-      mtu: 23,
+      local_mtu: local_mtu,
+      mtu: @default_mtu,
       read_buffer: <<>>,
       write_requests: []
     }
+  end
+
+  @doc false
+  def reset_mtu(state) do
+    %{state | mtu: @default_mtu}
+  end
+
+  @doc false
+  def current_mtu(state) do
+    state.mtu
   end
 
   @doc false
@@ -221,9 +234,10 @@ defmodule BlueHeron.GATT.Server do
   end
 
   @doc false
-  @spec exchange_mtu(t(), non_neg_integer()) :: {:ok, ExchangeMTURequest.t()}
-  def exchange_mtu(_state, mtu) do
-    {:ok, %ExchangeMTURequest{client_rx_mtu: mtu}}
+  @spec exchange_mtu(t(), non_neg_integer()) :: {t(), {:ok, ExchangeMTURequest.t()}}
+  def exchange_mtu(state, mtu) do
+    state = %{state | local_mtu: mtu}
+    {state, {:ok, %ExchangeMTURequest{client_rx_mtu: mtu}}}
   end
 
   @doc false
@@ -322,13 +336,16 @@ defmodule BlueHeron.GATT.Server do
     require_permission?(state, req, permission)
   end
 
-  defp exchange_mtu_request(state, _request) do
-    {state, %ExchangeMTUResponse{server_rx_mtu: state.mtu}}
+  defp exchange_mtu_request(state, request) do
+    state = %{state | mtu: negotiated_mtu(state.local_mtu, request.client_rx_mtu)}
+    {state, %ExchangeMTUResponse{server_rx_mtu: state.local_mtu}}
   end
 
   defp exchange_mtu_response(state, response) do
-    {%{state | mtu: response.server_rx_mtu}, nil}
+    {%{state | mtu: negotiated_mtu(state.local_mtu, response.server_rx_mtu)}, nil}
   end
+
+  defp negotiated_mtu(local_mtu, peer_mtu), do: min(local_mtu, peer_mtu)
 
   defp discover_all_primary_services(state, request) do
     services =

--- a/lib/blue_heron/peripheral.ex
+++ b/lib/blue_heron/peripheral.ex
@@ -51,9 +51,12 @@ defmodule BlueHeron.Peripheral do
   end
 
   @doc """
-  Get the current effective ATT MTU for the active connection.
+  Get the current effective ATT MTU.
+
+  Returns the spec default (23) before an MTU exchange has completed on the
+  active connection, and the negotiated value afterwards.
   """
-  @spec current_mtu() :: {:ok, non_neg_integer()} | {:error, :setup_incomplete | :no_connection}
+  @spec current_mtu() :: non_neg_integer()
   def current_mtu() do
     GenServer.call(__MODULE__, :current_mtu)
   end
@@ -231,20 +234,16 @@ defmodule BlueHeron.Peripheral do
   end
 
   @impl GenServer
+  def handle_call(:current_mtu, _from, state) do
+    {:reply, GATT.Server.current_mtu(state.gatt_server), state}
+  end
+
   def handle_call(_call, _from, %{ready?: false} = state) do
     {:reply, {:error, :setup_incomplete}, state}
   end
 
   def handle_call({:exchange_mtu, _local_mtu}, _from, %{connection: nil} = state) do
     {:reply, {:error, :no_connection}, state}
-  end
-
-  def handle_call(:current_mtu, _from, %{connection: nil} = state) do
-    {:reply, {:error, :no_connection}, state}
-  end
-
-  def handle_call(:current_mtu, _from, state) do
-    {:reply, {:ok, GATT.Server.current_mtu(state.gatt_server)}, state}
   end
 
   def handle_call({:exchange_mtu, local_mtu}, _from, state) do

--- a/lib/blue_heron/peripheral.ex
+++ b/lib/blue_heron/peripheral.ex
@@ -46,8 +46,16 @@ defmodule BlueHeron.Peripheral do
   Exchange MTU with a connected central.
   """
   @spec exchange_mtu(non_neg_integer()) :: :ok | {:error, term()}
-  def exchange_mtu(server_mtu) do
-    GenServer.call(__MODULE__, {:exchange_mtu, server_mtu})
+  def exchange_mtu(local_mtu) do
+    GenServer.call(__MODULE__, {:exchange_mtu, local_mtu})
+  end
+
+  @doc """
+  Get the current effective ATT MTU for the active connection.
+  """
+  @spec current_mtu() :: {:ok, non_neg_integer()} | {:error, :setup_incomplete | :no_connection}
+  def current_mtu() do
+    GenServer.call(__MODULE__, :current_mtu)
   end
 
   @doc """
@@ -83,14 +91,15 @@ defmodule BlueHeron.Peripheral do
   end
 
   @impl GenServer
-  def init(_) do
+  def init(args) do
     :ok = PropertyTable.subscribe(BlueHeron.GATT, ["profile"])
     profile = PropertyTable.get(BlueHeron.GATT, ["profile"], [])
+    local_mtu = Keyword.get(args, :local_mtu, 23)
 
     state = %{
       ready?: false,
       connection: nil,
-      gatt_server: GATT.Server.init(profile)
+      gatt_server: GATT.Server.init(profile, local_mtu)
     }
 
     :ok = BlueHeron.Registry.subscribe()
@@ -104,7 +113,7 @@ defmodule BlueHeron.Peripheral do
       )
       when is_list(profile) do
     Logger.info("Rebuilding GATT")
-    gatt_server = GATT.Server.init(profile)
+    gatt_server = GATT.Server.init(profile, state.gatt_server.local_mtu)
     new_state = %{state | gatt_server: gatt_server}
 
     if new_state.connection do
@@ -129,8 +138,9 @@ defmodule BlueHeron.Peripheral do
     }
 
     :ok = BlueHeron.SMP.set_connection(connection)
+    gatt_server = GATT.Server.reset_mtu(state.gatt_server)
 
-    {:noreply, %{state | connection: connection}}
+    {:noreply, %{state | connection: connection, gatt_server: gatt_server}}
   end
 
   def handle_info({:HCI_EVENT_PACKET, %EnhancedConnectionCompleteV1{} = event}, state) do
@@ -143,8 +153,9 @@ defmodule BlueHeron.Peripheral do
     }
 
     :ok = BlueHeron.SMP.set_connection(connection)
+    gatt_server = GATT.Server.reset_mtu(state.gatt_server)
 
-    {:noreply, %{state | connection: connection}}
+    {:noreply, %{state | connection: connection, gatt_server: gatt_server}}
   end
 
   def handle_info({:HCI_EVENT_PACKET, %DisconnectionComplete{} = pkt}, state) do
@@ -224,15 +235,23 @@ defmodule BlueHeron.Peripheral do
     {:reply, {:error, :setup_incomplete}, state}
   end
 
-  def handle_call({:exchange_mtu, _server_mtu}, _from, %{connection: nil} = state) do
+  def handle_call({:exchange_mtu, _local_mtu}, _from, %{connection: nil} = state) do
     {:reply, {:error, :no_connection}, state}
   end
 
-  def handle_call({:exchange_mtu, server_mtu}, _from, state) do
-    {:ok, request} = GATT.Server.exchange_mtu(state.gatt_server, server_mtu)
+  def handle_call(:current_mtu, _from, %{connection: nil} = state) do
+    {:reply, {:error, :no_connection}, state}
+  end
+
+  def handle_call(:current_mtu, _from, state) do
+    {:reply, {:ok, GATT.Server.current_mtu(state.gatt_server)}, state}
+  end
+
+  def handle_call({:exchange_mtu, local_mtu}, _from, state) do
+    {gatt_server, {:ok, request}} = GATT.Server.exchange_mtu(state.gatt_server, local_mtu)
     acl = build_l2cap_acl(state.connection.handle, 0x0004, request)
     reply = BlueHeron.HCI.Transport.buffer_acl(acl)
-    {:reply, reply, state}
+    {:reply, reply, %{state | gatt_server: gatt_server}}
   end
 
   def handle_call(

--- a/test/blue_heron/gatt/server_test.exs
+++ b/test/blue_heron/gatt/server_test.exs
@@ -10,6 +10,8 @@ defmodule BlueHeron.GATT.ServerTest do
 
   alias BlueHeron.ATT.{
     ErrorResponse,
+    ExchangeMTURequest,
+    ExchangeMTUResponse,
     FindInformationRequest,
     FindInformationResponse,
     PrepareWriteRequest,
@@ -131,6 +133,37 @@ defmodule BlueHeron.GATT.ServerTest do
       send(self(), value)
       :ok
     end
+  end
+
+  test "initializes with configured local mtu and default negotiated mtu" do
+    state = Server.init(TestServer.profile(), 512)
+
+    assert state.local_mtu == 512
+    assert state.mtu == 23
+    assert Server.current_mtu(state) == 23
+  end
+
+  test "stores negotiated mtu from exchange mtu request" do
+    state = Server.init(TestServer.profile(), 512)
+
+    {state, response} = Server.handle(state, %ExchangeMTURequest{client_rx_mtu: 247})
+
+    assert state.local_mtu == 512
+    assert state.mtu == 247
+    assert Server.current_mtu(state) == 247
+    assert %ExchangeMTUResponse{server_rx_mtu: 512} = response
+  end
+
+  test "stores negotiated mtu from exchange mtu response" do
+    state = Server.init(TestServer.profile(), 512)
+
+    {state, {:ok, request}} = Server.exchange_mtu(state, 512)
+    assert %ExchangeMTURequest{client_rx_mtu: 512} = request
+
+    {state, nil} = Server.handle(state, %ExchangeMTUResponse{server_rx_mtu: 247})
+
+    assert state.local_mtu == 512
+    assert state.mtu == 247
   end
 
   test "discover all primary services" do

--- a/test/blue_heron/peripheral_test.exs
+++ b/test/blue_heron/peripheral_test.exs
@@ -8,31 +8,29 @@ defmodule BlueHeron.PeripheralTest do
   alias BlueHeron.GATT.Server
   alias BlueHeron.Peripheral
 
-  test "current_mtu returns setup incomplete before peripheral is ready" do
-    state = state(ready?: false, connection: %{handle: 1})
+  test "current_mtu returns the spec default before the peripheral is ready" do
+    state = state(ready?: false)
 
-    assert {:reply, {:error, :setup_incomplete}, ^state} =
-             Peripheral.handle_call(:current_mtu, self(), state)
+    assert {:reply, 23, ^state} = Peripheral.handle_call(:current_mtu, self(), state)
   end
 
-  test "current_mtu returns no connection when peripheral is ready without a connection" do
+  test "current_mtu returns the spec default when there is no connection" do
     state = state()
 
-    assert {:reply, {:error, :no_connection}, ^state} =
-             Peripheral.handle_call(:current_mtu, self(), state)
+    assert {:reply, 23, ^state} = Peripheral.handle_call(:current_mtu, self(), state)
   end
 
-  test "current_mtu returns default mtu before mtu exchange" do
+  test "current_mtu returns the spec default before mtu exchange" do
     state = state(connection: %{handle: 1})
 
-    assert {:reply, {:ok, 23}, ^state} = Peripheral.handle_call(:current_mtu, self(), state)
+    assert {:reply, 23, ^state} = Peripheral.handle_call(:current_mtu, self(), state)
   end
 
-  test "current_mtu returns negotiated mtu" do
+  test "current_mtu returns the negotiated mtu" do
     gatt_server = %{Server.init([], 512) | mtu: 247}
     state = state(connection: %{handle: 1}, gatt_server: gatt_server)
 
-    assert {:reply, {:ok, 247}, ^state} = Peripheral.handle_call(:current_mtu, self(), state)
+    assert {:reply, 247, ^state} = Peripheral.handle_call(:current_mtu, self(), state)
   end
 
   defp state(overrides \\ []) do

--- a/test/blue_heron/peripheral_test.exs
+++ b/test/blue_heron/peripheral_test.exs
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2026 BlueHeron Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule BlueHeron.PeripheralTest do
+  use ExUnit.Case
+
+  alias BlueHeron.GATT.Server
+  alias BlueHeron.Peripheral
+
+  test "current_mtu returns setup incomplete before peripheral is ready" do
+    state = state(ready?: false, connection: %{handle: 1})
+
+    assert {:reply, {:error, :setup_incomplete}, ^state} =
+             Peripheral.handle_call(:current_mtu, self(), state)
+  end
+
+  test "current_mtu returns no connection when peripheral is ready without a connection" do
+    state = state()
+
+    assert {:reply, {:error, :no_connection}, ^state} =
+             Peripheral.handle_call(:current_mtu, self(), state)
+  end
+
+  test "current_mtu returns default mtu before mtu exchange" do
+    state = state(connection: %{handle: 1})
+
+    assert {:reply, {:ok, 23}, ^state} = Peripheral.handle_call(:current_mtu, self(), state)
+  end
+
+  test "current_mtu returns negotiated mtu" do
+    gatt_server = %{Server.init([], 512) | mtu: 247}
+    state = state(connection: %{handle: 1}, gatt_server: gatt_server)
+
+    assert {:reply, {:ok, 247}, ^state} = Peripheral.handle_call(:current_mtu, self(), state)
+  end
+
+  defp state(overrides \\ []) do
+    %{
+      ready?: Keyword.get(overrides, :ready?, true),
+      connection: Keyword.get(overrides, :connection, nil),
+      gatt_server: Keyword.get(overrides, :gatt_server, Server.init([]))
+    }
+  end
+end


### PR DESCRIPTION
## Summary
Adds support for configuring a local ATT MTU and querying the currently negotiated MTU on the active peripheral connection. Previously the GATT server hard-coded a 23-byte MTU and `exchange_mtu/1` did not record the negotiated value, so callers had no way to size attribute reads/writes for the connection.

## Changes
- `BlueHeron.GATT.Server`
  - New `local_mtu` field (advertised to peers) separate from `mtu` (current negotiated value).
  - `init/2` accepts the configured local MTU; defaults to 23.
  - `exchange_mtu/2` now returns the updated state alongside the request.
  - Both the request and response paths compute the negotiated MTU as `min(local_mtu, peer_mtu)` per spec.
  - Adds `current_mtu/1` and `reset_mtu/1` helpers.
- `BlueHeron.Peripheral`
  - Reads `local_mtu` from `:blue_heron, :peripheral` app env (default 23).
  - New public `current_mtu/0` returning `{:ok, mtu} | {:error, :setup_incomplete | :no_connection}`.
  - Resets the negotiated MTU back to 23 on every new connection / re-connection so a stale value from a prior link cannot leak across connections.
  - Profile rebuilds preserve the configured `local_mtu`.
- `BlueHeron.Application` threads the `:peripheral` keyword list into `BlueHeron.Peripheral`.
- README: documents the `peripheral: [local_mtu: 512]` config knob in the upgrade section.

## Config
```elixir
config :blue_heron,
  peripheral: [local_mtu: 512]
```

## Tests
- `GATT.ServerTest`: init with custom local MTU; negotiated MTU stored from both `ExchangeMTURequest` (server-side) and `ExchangeMTUResponse` (client-side); response advertises `local_mtu`.
- New `PeripheralTest`: `current_mtu/0` returns `:setup_incomplete`, `:no_connection`, the default 23 pre-exchange, and the negotiated value post-exchange.


This addresses #137 