### PR TITLE
Add Peripheral.add_services/1 for batch service registration

### DIFF
--- a/lib/blue_heron/peripheral.ex
+++ b/lib/blue_heron/peripheral.ex
@@ -68,6 +68,19 @@ defmodule BlueHeron.Peripheral do
   end
 
   @doc """
+  Register multiple services in the GATT in a single batch.
+
+  Equivalent to calling `add_service/1` for each service, but triggers a
+  single GATT rebuild — and at most one disconnect of an active connection
+  — instead of one per service.
+  """
+  @spec add_services([Service.t()]) :: :ok
+  def add_services(services) when is_list(services) do
+    existing = PropertyTable.get(BlueHeron.GATT, ["profile"], [])
+    PropertyTable.put(BlueHeron.GATT, ["profile"], services ++ existing)
+  end
+
+  @doc """
   Delete a service by it's ID.
   """
   @spec delete_service(Service.id()) :: :ok

--- a/test/blue_heron/peripheral_test.exs
+++ b/test/blue_heron/peripheral_test.exs
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2026 BlueHeron Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule BlueHeron.PeripheralTest do
+  use ExUnit.Case
+
+  alias BlueHeron.GATT.Service
+  alias BlueHeron.Peripheral
+
+  setup_all do
+    Application.stop(:blue_heron)
+    :ok
+  end
+
+  setup do
+    start_supervised!({PropertyTable, name: BlueHeron.GATT})
+    :ok
+  end
+
+  describe "add_services/1" do
+    test "appends all services to the profile in a single PropertyTable update" do
+      PropertyTable.subscribe(BlueHeron.GATT, ["profile"])
+
+      a = %Service{id: :a, type: 0x2800, characteristics: []}
+      b = %Service{id: :b, type: 0x2800, characteristics: []}
+
+      assert :ok = Peripheral.add_services([a, b])
+
+      assert_receive %PropertyTable.Event{
+                       table: BlueHeron.GATT,
+                       property: ["profile"],
+                       value: [^a, ^b]
+                     }
+
+      refute_receive %PropertyTable.Event{table: BlueHeron.GATT}, 50
+      assert PropertyTable.get(BlueHeron.GATT, ["profile"]) == [a, b]
+    end
+
+    test "prepends to existing services" do
+      seed = %Service{id: :seed, type: 0x2800, characteristics: []}
+      PropertyTable.put(BlueHeron.GATT, ["profile"], [seed])
+
+      new = %Service{id: :new, type: 0x2800, characteristics: []}
+      assert :ok = Peripheral.add_services([new])
+
+      assert PropertyTable.get(BlueHeron.GATT, ["profile"]) == [new, seed]
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`BlueHeron.Peripheral.add_service/1` does one `PropertyTable.put` per call, and each put fires the profile subscription handler in `Peripheral` which rebuilds the entire GATT server (and disconnects any active connection). Registering N services at startup therefore causes N rebuilds.

This PR adds `add_services/1`, which merges the new list with the existing profile in a single `PropertyTable.put`, so the rebuild fires once regardless of batch size.

```elixir
BlueHeron.Peripheral.add_services([service_a, service_b, service_c])
```

is equivalent to three sequential `add_service/1` calls, but produces a single `%PropertyTable.Event{}` and therefore a single `GATT.Server.init/1`.

## Notes

- New services are prepended to the existing profile (`services ++ existing`), matching the existing convention that `add_service/1` prepends.
- No change to `add_service/1` behavior — existing callers are unaffected.

## Test plan

- [x] `mix test` (40 tests, 13 doctests, 0 failures)
- [x] New `BlueHeron.PeripheralTest` subscribes to the GATT `PropertyTable` and asserts that a batch of two services produces exactly one `%PropertyTable.Event{}` (verified with `refute_receive` after the first event)
- [x] Order assertion: existing `[seed]` + `add_services([new])` results in `[new, seed]`